### PR TITLE
Fix/single encounter

### DIFF
--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -21,7 +21,3 @@
   border-left: solid $gdGreen 2px;
   border-right: solid $gdGreen 2px;
 }
-
-@mixin encounterMarg {
-    margin: 10px 0 10px 0;
-}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -24,7 +24,7 @@ class App extends Component {
   addEncounter = (newEncounter, floor, list) => {
     const newEncounterState = this.state.encounterLists;
     if (list === 'random') {
-      newEncounterState[floor][list].push(newEncounter);
+      newEncounterState[floor][list] = [newEncounter];
     } else {
       newEncounterState[floor][list] = newEncounter;
     }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -12,11 +12,10 @@ class App extends Component {
     super();
     this.state = {
       floorData: floors,
-      savedEncounters: [],
       error:'',
       encounterLists: {
-        'theBell': {premade: [], random:[]}, //maybe saved encounters go here too
-        'floor1': {premade: [], random:[]}
+        'theBell': {saved: [], random:[]},
+        'floor1': {saved: [], random:[]}
       }
     }
   }

--- a/src/components/Encounter/Encounter.js
+++ b/src/components/Encounter/Encounter.js
@@ -108,9 +108,6 @@ const Encounter = ({ floor, eData, list, addEncounter, encounterList }) => {
         {eData.tags!=='short' && (
           <button onClick={reroll}>REROLL</button>)
         }
-        {list==='random' && (
-          <button>DELETE</button>)
-        }
       </div>
     </aside>
   )
@@ -125,3 +122,9 @@ Encounter.propTypes = {
   list: PropTypes.string,
   addEncounter: PropTypes.func
 }
+
+
+
+// {list==='random' && (
+//   <button>DELETE</button>)
+// }

--- a/src/components/Encounter/Encounter.js
+++ b/src/components/Encounter/Encounter.js
@@ -19,13 +19,13 @@ const Encounter = ({ floor, eData, list, addEncounter, encounterList }) => {
     description = '';
     if (eData.count) {
       switch(eData.count) {
-        case '1.10':
+        case '1d10':
           count = eData.d10s[0]
           break;
-        case '1.5':
+        case '1d5':
           count = Math.round((eData.d10s[0])/2)
           break;
-        case '2.10':
+        case '2d10':
           count = (eData.d10s[0] + eData.d10s[1]);
           break;
       }

--- a/src/components/Encounter/Encounter.js
+++ b/src/components/Encounter/Encounter.js
@@ -106,7 +106,7 @@ const Encounter = ({ floor, eData, list, addEncounter, encounterList }) => {
       <div className='btn-container'>
         <button>SAVE</button>
         {eData.tags!=='short' && (
-          <button onClick={reroll}>REROLL</button>)
+          <button onClick={reroll}>REROLL DETAILS</button>)
         }
       </div>
     </aside>

--- a/src/components/Encounter/Encounter.scss
+++ b/src/components/Encounter/Encounter.scss
@@ -3,9 +3,9 @@
 .encounter-container {
   width: 100%;
   background: black;
-  border: solid $gdGreenSolid 2px;
+  border: solid $gdGreenSolid 6px;
   padding: 10px;
-  @include encounterMarg;
+  // @include encounterMarg;
 
   .description {
     font-size: 18px;

--- a/src/components/Encounter/Encounter.scss
+++ b/src/components/Encounter/Encounter.scss
@@ -36,7 +36,7 @@
   }
 
   button {
-    width: 30%;
+    width: 40%;
     padding: 2px;
     // margin: 8px;
   }

--- a/src/components/Floor/Floor.js
+++ b/src/components/Floor/Floor.js
@@ -29,34 +29,9 @@ const Floor = ({ floorID, floorName, encounterData, encounterList, addEncounter}
     const roll = rollDice('1d10')
     const newEncounter = encounterData[formatRoll(roll)];
     addDice(newEncounter);
-    newEncounter.id = getID() + d100().value;
+    newEncounter.id = getID();
     addEncounter(newEncounter, floorID, 'random');
   }
-
-  // const createSideBar = () => {
-  //   const encounterKeys = Object.keys(encounterData);
-  //   const encounterList = encounterKeys.reduce((list,key, index) => {
-  //     const nonRepeatList = [0,1,4,7,9];
-  //     if (nonRepeatList.includes(index)) {
-  //       const newEncounter = encounterData[key];
-  //       console.log(newEncounter);
-  //     }
-  //     return list
-  //   }, [])
-  // }
-
-  // const preMadeEncounters = encounterList.premade.map((encounter, index) => {
-  //   return (
-  //     <Encounter
-  //       floor={floorID}
-  //       eData={encounter}
-  //       key={index}
-  //       addEncounter={addEncounter}
-  //       encounterList={encounterList}
-  //       list={'preMade'}
-  //     />
-  //   )
-  // })
 
   const randomEncounters = encounterList.random.map((encounter, index) => {
     return (
@@ -77,9 +52,9 @@ const Floor = ({ floorID, floorName, encounterData, encounterList, addEncounter}
   },[])
 
 
-  // useEffect(() => {
-  //   createPremadeList();
-  // },[location.pathname])
+  useEffect(() => {
+    rollEncounter();
+  },[location.pathname])
 
   return (
     <section className='floor-container'>
@@ -101,6 +76,7 @@ const Floor = ({ floorID, floorName, encounterData, encounterList, addEncounter}
           <li>{sideBarList[3]}</li>
           <li>{sideBarList[4]}</li>
         </ol>
+        <div className='responsive-block'></div>
         </aside>
       </section>
     </section>

--- a/src/components/Floor/Floor.js
+++ b/src/components/Floor/Floor.js
@@ -57,11 +57,6 @@ const Floor = ({ floorID, floorName, encounterData, encounterList, addEncounter}
     )
   })
 
-
-  //useEffect to prevent weird rerender problem
-  //add another create list function to call on useEffect to ensure both list are stable
-  //roll dice in floor then pass those down to encounters for initial
-
   useEffect(() => {
     createPremadeList();
   },[])
@@ -75,17 +70,16 @@ const Floor = ({ floorID, floorName, encounterData, encounterList, addEncounter}
     <section className='floor-container'>
       <h2 className='floor-title'>{floorName}</h2>
       <nav className='floor-controls'>
-        <button>RANDOM ENCOUNTERS</button>
-        <button>ENCOUNTER LIST</button>
+        <button onClick={rollEncounter}className='new-random'>GENERATE ENCOUNTER</button>
       </nav>
       <section className='encounter-grid'>
-        <div className='premade'>
-          {preMadeEncounters}
-        </div>
-        <div className='random'>
+        <section className='random'>
           {randomEncounters}
-          <button onClick={rollEncounter}className='new-random'>+</button>
-        </div>
+        </section>
+        <h3 className='premade'>ENCOUNTER LIST</h3>
+        <aside >
+          {preMadeEncounters}
+        </aside>
       </section>
     </section>
   )
@@ -99,3 +93,5 @@ Floor.propTypes = {
   encounterData: PropTypes.object,
   addEncounter: PropTypes.func
 };
+
+// <button onClick={rollEncounter}className='new-random'>roll new encounter</button>

--- a/src/components/Floor/Floor.js
+++ b/src/components/Floor/Floor.js
@@ -2,47 +2,61 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import './Floor.scss';
 import Encounter from '../Encounter/Encounter';
-import { getID, formatIndex, rollDice, d100, formatRoll, addDice } from '../../utilities';
+import { getID, formatIndex, rollDice, d100, formatRoll, addDice, formatSideBar } from '../../utilities';
 
 const Floor = ({ floorID, floorName, encounterData, encounterList, addEncounter}) => {
 
-  const [premadeEncounterList, setPreEnc] = useState([])
+  const [sideBarList, setSideBar] = useState([])
 
-  const createPremadeList = () => {
+  const createSideBar = () => {
     const encounterKeys = Object.keys(encounterData);
-    const encounterList = encounterKeys.reduce((list,key, index) => {
+    const encounterList = encounterKeys.reduce((list, key, index) => {
       const nonRepeatList = [0,1,4,7,9];
       if (nonRepeatList.includes(index)) {
-        const newEncounter = encounterData[key];
-        addDice(newEncounter);
-        newEncounter.id = getID() + d100().value;
-        list.push(encounterData[key]);
+        const newEncounter = {
+            count: encounterData[key].count,
+            description: encounterData[key].description
+          }
+
+        list.push(newEncounter);
       }
       return list
     }, [])
-    addEncounter(encounterList, floorID, 'premade');
+    setSideBar(formatSideBar(encounterList))
   }
 
   const rollEncounter = () => {
-    const roll = rollDice('1.10')
+    const roll = rollDice('1d10')
     const newEncounter = encounterData[formatRoll(roll)];
     addDice(newEncounter);
     newEncounter.id = getID() + d100().value;
     addEncounter(newEncounter, floorID, 'random');
   }
 
-  const preMadeEncounters = encounterList.premade.map((encounter, index) => {
-    return (
-      <Encounter
-        floor={floorID}
-        eData={encounter}
-        key={index}
-        addEncounter={addEncounter}
-        encounterList={encounterList}
-        list={'preMade'}
-      />
-    )
-  })
+  // const createSideBar = () => {
+  //   const encounterKeys = Object.keys(encounterData);
+  //   const encounterList = encounterKeys.reduce((list,key, index) => {
+  //     const nonRepeatList = [0,1,4,7,9];
+  //     if (nonRepeatList.includes(index)) {
+  //       const newEncounter = encounterData[key];
+  //       console.log(newEncounter);
+  //     }
+  //     return list
+  //   }, [])
+  // }
+
+  // const preMadeEncounters = encounterList.premade.map((encounter, index) => {
+  //   return (
+  //     <Encounter
+  //       floor={floorID}
+  //       eData={encounter}
+  //       key={index}
+  //       addEncounter={addEncounter}
+  //       encounterList={encounterList}
+  //       list={'preMade'}
+  //     />
+  //   )
+  // })
 
   const randomEncounters = encounterList.random.map((encounter, index) => {
     return (
@@ -58,27 +72,35 @@ const Floor = ({ floorID, floorName, encounterData, encounterList, addEncounter}
   })
 
   useEffect(() => {
-    createPremadeList();
+    rollEncounter();
+    createSideBar();
   },[])
 
 
-  useEffect(() => {
-    createPremadeList();
-  },[location.pathname])
+  // useEffect(() => {
+  //   createPremadeList();
+  // },[location.pathname])
 
   return (
     <section className='floor-container'>
       <h2 className='floor-title'>{floorName}</h2>
       <nav className='floor-controls'>
-        <button onClick={rollEncounter}className='new-random'>GENERATE ENCOUNTER</button>
       </nav>
       <section className='encounter-grid'>
-        <section className='random'>
+        <button onClick={rollEncounter}className='new-random'>GENERATE ENCOUNTER</button>
+        <section className='encounter'>
           {randomEncounters}
         </section>
-        <h3 className='premade'>ENCOUNTER LIST</h3>
-        <aside >
-          {preMadeEncounters}
+
+        <aside className='encounter-sidebar'>
+        <h3 className='encounter-list-title'>ENCOUNTER LIST</h3>
+        <ol className='encounter-list'>
+          <li>{sideBarList[0]}</li>
+          <li>{sideBarList[1]}</li>
+          <li>{sideBarList[2]}</li>
+          <li>{sideBarList[3]}</li>
+          <li>{sideBarList[4]}</li>
+        </ol>
         </aside>
       </section>
     </section>
@@ -93,5 +115,5 @@ Floor.propTypes = {
   encounterData: PropTypes.object,
   addEncounter: PropTypes.func
 };
-
+    // {preMadeEncounters}
 // <button onClick={rollEncounter}className='new-random'>roll new encounter</button>

--- a/src/components/Floor/Floor.scss
+++ b/src/components/Floor/Floor.scss
@@ -76,5 +76,5 @@
     color: white;
     font-size: 20px;
     border: solid $gdGreenSolid 5px;
-    @include encounterMarg;
+  margin: 15px 0 -5px 0;
   }

--- a/src/components/Floor/Floor.scss
+++ b/src/components/Floor/Floor.scss
@@ -29,16 +29,21 @@
   }
 }
 
+
   .encounter-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 2fr 1fr;
     grid-template-rows: 1fr;
-    grid-column-gap: 5px;
+    grid-column-gap: 0px;
     grid-row-gap: 0px;
   }
 
   .premade {
     grid-area: 1 / 2 / 2 / 3;
+    width: 100%;
+    text-align: center;
+    background: $gdGreenSolid;
+    color:white;
   }
 
   .random {
@@ -49,7 +54,7 @@
     width: 100%;
     background: $gdGreen;
     color: white;
-    font-size: 60px;
+    font-size: 20px;
     border: solid $gdGreenSolid 5px;
     @include encounterMarg;
   }

--- a/src/components/Floor/Floor.scss
+++ b/src/components/Floor/Floor.scss
@@ -12,13 +12,15 @@
   text-align: center;
   font-size: 30px;
   padding: 0 0 10px 0;
+  grid-area: 1 / 1 / 2 / 2;
 }
 
 .floor-controls {
   // @include floorBorder;
-  margin: 0 auto;
+  // margin: 0 auto;
   display: flex;
   justify-content: space-around;
+  text-align: left;
 
   button {
     border: none;
@@ -28,30 +30,48 @@
 
   }
 }
-
-
   .encounter-grid {
     display: grid;
     grid-template-columns: 2fr 1fr;
-    grid-template-rows: 1fr;
+    grid-template-rows: .25fr 1fr;
     grid-column-gap: 0px;
     grid-row-gap: 0px;
   }
 
-  .premade {
-    grid-area: 1 / 2 / 2 / 3;
+  .encounter-sidebar {
+    grid-area: 2 / 2 / 3 / 3;
+    // grid-area: 1 / 2 / 3 / 3;;
+  }
+
+  .encounter-list-title {
     width: 100%;
+    font-size: 20px;
     text-align: center;
     background: $gdGreenSolid;
     color:white;
   }
 
-  .random {
-    grid-area: 1 / 1 / 2 / 2;
+  .encounter-list {
+    width: 100%;
+    font-size: 14px;
+    text-align: left;
+    background: black;
+    color:white;
+    border: $gdGreenSolid solid 3px;
+
+    li {
+      margin:10px;
+    }
+  }
+
+  .encounter {
+    grid-area: 2 / 1 / 3 / 2;
   }
 
   .new-random {
+    grid-area: 1 / 1 / 2 / 3;;
     width: 100%;
+    max-height: 40px;
     background: $gdGreen;
     color: white;
     font-size: 20px;

--- a/src/data/gdData.js
+++ b/src/data/gdData.js
@@ -70,19 +70,19 @@ export const floors = {
       '01': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'forgotten'
       },
       '02': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'forgotten'
       },
       '03': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'forgotten'
       },
       '04': {
@@ -124,7 +124,7 @@ export const floors = {
       '10': {
         'description': 'Troubleshooter' ,
         'reference': 'pg. 14',
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'name'
     }
   },
@@ -134,37 +134,37 @@ export const floors = {
       '01': {
         'description': 'Chosen Android',
         'reference': 'pg. 24',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '02': {
         'description': 'Chosen Android',
         'reference': 'pg. 24',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '03': {
         'description': 'Chosen Android',
         'reference': 'pg. 24',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '04': {
         'description': 'Fallen Android',
         'reference': 'pg. 24',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '05': {
         'description': 'Fallen Android',
         'reference': 'pg. 24',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '06': {
         'description': 'Fallen Android',
         'reference': 'pg. 24',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '07': {
@@ -199,37 +199,37 @@ export const floors = {
       '01': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '02': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '03': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '04': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '05': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '06': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '07': {
@@ -264,49 +264,49 @@ export const floors = {
       '01': {
         'description': 'Bee Drone' ,
         'reference': 'pg. 38',
-        'count': '2.10',
+        'count': '2d10',
         'tags': ''
       },
       '02': {
         'description': 'Bee Drone' ,
         'reference': 'pg. 38',
-        'count': '2.10',
+        'count': '2d10',
         'tags': ''
       },
       '03': {
         'description': 'Bee Drone' ,
         'reference': 'pg. 38',
-        'count': '2.10',
+        'count': '2d10',
         'tags': ''
       },
       '04': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '05': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '06': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '07': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '08': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '09': {
@@ -347,31 +347,31 @@ export const floors = {
       '04': {
         'description': 'Pseudomilk Eel' ,
         'reference': 'pg. 42',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '05': {
         'description': 'Pseudomilk Eel' ,
         'reference': 'pg. 42',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '06': {
         'description': 'Pseudomilk Eel' ,
         'reference': 'pg. 42',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '07': {
         'description': 'Stunted Android',
         'reference':'pg. 41',
-        'count': '1.5',
+        'count': '1d5',
         'tags':''
       },
       '08': {
         'description': 'Stunted Android',
         'reference':'pg. 41',
-        'count': '1.5',
+        'count': '1d5',
         'tags':''
       },
       '09': {
@@ -394,19 +394,19 @@ export const floors = {
       '01': {
         'description': 'Escaped Child Android(s) from HEL seeking the Mind Thief' ,
         'reference': 'pg. 45',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '02': {
         'description': 'Escaped Child Android(s) from HEL seeking the Mind Thief' ,
         'reference': 'pg. 45',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '03': {
         'description': 'Escaped Child Android(s) from HEL seeking the Mind Thief' ,
         'reference': 'pg. 45',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '04': {
@@ -430,13 +430,13 @@ export const floors = {
       '07': {
         'description': 'Android Dog',
         'reference': 'pg. 44',
-        'count':' 1.5' ,
+        'count':' 1d5' ,
         'tags':''
       },
       '08': {
         'description': 'Android Dog',
         'reference': 'pg. 44',
-        'count':' 1.5' ,
+        'count':' 1d5' ,
         'tags':''
       },
       '09': {
@@ -459,49 +459,49 @@ export const floors = {
       '01': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '02': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '03': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '04': {
         'description': 'Failed Android(s) looking to escape Disassembly ',
         'reference': 'pg. 49',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '05': {
         'description': 'Failed Android(s) looking to escape Disassembly ',
         'reference': 'pg. 49',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '06': {
         'description': 'Failed Android(s) looking to escape Disassembly ',
         'reference': 'pg. 49',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '07': {
         'description': 'Security Android chasing escapees',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '08': {
         'description': 'Security Android chasing escapees',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '09': {
@@ -524,49 +524,49 @@ export const floors = {
       '01': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '02': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '03': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'forgotten'
       },
       '04': {
         'description': 'Failed Android(s) looking to escape Disassembly ',
         'reference': 'pg. 49',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '05': {
         'description': 'Failed Android(s) looking to escape Disassembly ',
         'reference': 'pg. 49',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '06': {
         'description': 'Failed Android(s) looking to escape Disassembly ',
         'reference': 'pg. 49',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '07': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '08': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '09': {
@@ -589,37 +589,37 @@ export const floors = {
       '01': {
         'description': 'Diver',
         'reference': '',
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'name'
       },
       '02': {
         'description': 'Diver',
         'reference': '',
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'name'
       },
       '03': {
         'description': 'Diver',
         'reference': '',
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'name'
       },
       '04': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '05': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '06': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       },
       '07': {
@@ -643,7 +643,7 @@ export const floors = {
       '10': {
         'description': 'Exact duplicates of the crew (+1d10 Bend & Bend Check)',
         'reference': 'pg. 10',
-        'count': '1.10',
+        'count': '1d10',
         'tags': ''
       }
     }
@@ -654,49 +654,49 @@ export const floors = {
       '01': {
         'description': 'Escaped Child Android' ,
         'reference': 'pg. 54',
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'child'
       },
       '02': {
         'description': 'Escaped Child Android' ,
         'reference': 'pg. 54',
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'child'
       },
       '03': {
         'description': 'Escaped Child Android' ,
         'reference': 'pg. 54',
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'child'
       },
       '04': {
         'description': 'Former CLOUDBANK Research Scientist',
         'reference': '',
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'name'
       },
       '05': {
         'description': 'Former CLOUDBANK Research Scientist',
         'reference': '',
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'name'
       },
       '06': {
         'description': 'Former CLOUDBANK Research Scientist',
         'reference': '',
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'name'
       },
       '07': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '08': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '09': {
@@ -720,43 +720,43 @@ export const floors = {
       '01': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'forgotten'
       },
       '02': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'forgotten'
       },
       '03': {
         'description': 'Forgotten Android',
         'reference': 'pg. 11' ,
-        'count': '1.5',
+        'count': '1d5',
         'tags': 'forgotten'
       },
       '04': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '05': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '06': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '07': {
         'description': 'Security Android',
         'reference':'pg. 10',
-        'count': '1.5',
+        'count': '1d5',
         'tags': ''
       },
       '08': {
@@ -774,7 +774,7 @@ export const floors = {
       '10': {
         'description': 'Troubleshooter' ,
         'reference': 'pg. 14',
-        'count': '1.10',
+        'count': '1d10',
         'tags': 'name'
       }
     }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -2,6 +2,14 @@ export const shuffleItems = (array) => {
   return array.sort(() => 0.5 - Math.random());
 }
 
+export const formatSideBar = (encArray) => {
+  return encArray.map(encounter => {
+    return encounter.count ?
+      `${encounter.count} ${encounter.description}`:
+      `${encounter.description}`
+  })
+}
+
 export const getID = () => {
   const rawID = Date.now().toString().split('');
   return parseInt(shuffleItems(rawID).join(''));
@@ -19,7 +27,7 @@ export const formatRoll = (num) => {
 }
 
 export const rollDice = (diceCount) => {
-  const diceData = diceCount.split('.');
+  const diceData = diceCount.split('d');
   let value = 0
   for (let i = 0; i < diceData[0]; i++) {
     value =+ value + (1 + Math.floor(Math.random()*diceData[1]))
@@ -35,7 +43,7 @@ export const d100 = () => {
 }
 
 export const addDice = (encounter) => {
-  encounter.d10s = [rollDice('1.10'),rollDice('1.10'),rollDice('1.10'),rollDice('1.10'),rollDice('1.10')]
+  encounter.d10s = [rollDice('1d10'),rollDice('1d10'),rollDice('1d10'),rollDice('1d10'),rollDice('1d10')]
   encounter.d100s = [d100(), d100()]
 }
 


### PR DESCRIPTION
## Is this a fix or a feature?
Fix
## What is the change?
Each floor now shows a single encounter and a list of potential encounters, it's cleaner and simpler and better. 
## What does it fix?
Avoids the issue of multiple keys caused by keys morphing following the addition of a new encounter.
## Where should the reviewer start?
Review the encounter component to see the new styling
## How should this be tested?
Confirm that only single encounters can be loaded