### PR TITLE
remove bug in window.location within useEffect in floor

### DIFF
--- a/src/components/Floor/Floor.js
+++ b/src/components/Floor/Floor.js
@@ -51,10 +51,10 @@ const Floor = ({ floorID, floorName, encounterData, encounterList, addEncounter}
     createSideBar();
   },[])
 
-  useEffect(() => {
-    rollEncounter();
-    createSideBar();
-  },[location.pathname])
+  // useEffect(() => {
+  //   rollEncounter();
+  //   createSideBar();
+  // },[location.pathname])
 
   return (
     <>


### PR DESCRIPTION
## Is this a fix or a feature?
Fix
## What is the change?
Remove the use of window.location in useEffect within Floor.js. 
## What does it fix?
Fixes the compile bug
## Where should the reviewer start?
Lines 54-75 in Floor.js still contain the commented out code for reference
## How should this be tested?
Run the app